### PR TITLE
Fixed a potential buffer overrun when parsing WAD paths

### DIFF
--- a/engine/common/identification.c
+++ b/engine/common/identification.c
@@ -325,7 +325,6 @@ int ID_RunWMIC(char *buffer, const char *cmdline)
 	bSuccess = ReadFile( g_OUT_Rd, buffer, BUFSIZE, &dwRead, NULL );
 	buffer[BUFSIZE-1] = 0;
 	CloseHandle( g_IN_Rd );
-	CloseHandle( g_IN_Wr );
 	CloseHandle( g_OUT_Rd );
 
 	return bSuccess;

--- a/engine/common/model.c
+++ b/engine/common/model.c
@@ -2300,14 +2300,17 @@ static void Mod_LoadEntities( const dlump_t *l )
 			{
 				char	*path = token;
 				string	wadpath;
-				wadpath[MAX_STRING - 1] = '\0';
+				size_t charsLeftInBuffer;
 
-				// Excludes terminator.
-				size_t charsLeftInBuffer = MAX_STRING - 1;
+				// Stick a null on the end just in case. The rest of the chars can be written to.
+				wadpath[MAX_STRING - 1] = '\0';
+				charsLeftInBuffer = MAX_STRING - 1;
 
 				// parse wad pathes
 				while( path && *path )
 				{
+					size_t sizeOfPath, charsCopied;
+
 					char *end = Q_strchr( path, ';' );
 					if( !end )
 						end = path + Q_strlen( path );
@@ -2319,13 +2322,13 @@ static void Mod_LoadEntities( const dlump_t *l )
 						break;
 					}
 
-					size_t sizeOfPath = (end - path) + 1;
+					sizeOfPath = (end - path) + 1;
 					if (sizeOfPath > charsLeftInBuffer)
 					{
 						break;
 					}
 
-					size_t charsCopied = Q_strncpy( wadpath, path, sizeOfPath );
+					charsCopied = Q_strncpy( wadpath, path, sizeOfPath );
 					charsLeftInBuffer -= charsCopied;
 
 					FS_FileBase( wadpath, wadlist.wadnames[wadlist.count++] );

--- a/engine/common/model.c
+++ b/engine/common/model.c
@@ -2300,6 +2300,10 @@ static void Mod_LoadEntities( const dlump_t *l )
 			{
 				char	*path = token;
 				string	wadpath;
+				wadpath[MAX_STRING - 1] = '\0';
+
+				// Excludes terminator.
+				size_t charsLeftInBuffer = MAX_STRING - 1;
 
 				// parse wad pathes
 				while( path && *path )
@@ -2314,8 +2318,23 @@ static void Mod_LoadEntities( const dlump_t *l )
 							FS_FileBase( path, wadlist.wadnames[wadlist.count++] );
 						break;
 					}
-					Q_strncpy( wadpath, path, (end - path) + 1 );
+
+					size_t sizeOfPath = (end - path) + 1;
+					if (sizeOfPath > charsLeftInBuffer)
+					{
+						break;
+					}
+
+					size_t charsCopied = Q_strncpy( wadpath, path, sizeOfPath );
+					charsLeftInBuffer -= charsCopied;
+
 					FS_FileBase( wadpath, wadlist.wadnames[wadlist.count++] );
+
+					if (end && *end == '\0')
+					{
+						break;
+					}
+
 					path += (end - path) + 1; // move pointer
 					if( wadlist.count >= 256 ) break; // too many wads...
 				}


### PR DESCRIPTION
The code assumed that the source string would be filled with nulls after the end of the string, which was definitely not the case when building in Debug. This caused stack corruption when starting a new game, as garbage data from the source string was copied blindly into the destination buffer.

The code has been modified so that a WAD path will not be copied in if it would overflow the buffer, and an extra check has been added to terminate the loop if the end of the source string is reached.

In addition, I found another issue while debugging where a pipe handle was being closed twice. This is also fixed here.