### PR TITLE
Software Based Strobing Implementation (Black Frame Insertion)

### DIFF
--- a/engine/client/cl_scrn.c
+++ b/engine/client/cl_scrn.c
@@ -101,6 +101,18 @@ void SCR_DrawFPS( void )
 		/*if( !avgrate ) avgrate = ( maxfps - minfps ) / 2.0f;
 		else */avgrate += ( calc - avgrate ) / host.framecount;
 
+		int strobeInterval = r_strobe->integer;
+		int eFPS; //Effective FPS (strobing effect)
+		if (strobeInterval > 0)
+		{
+			eFPS = (int)((curfps) / (strobeInterval + 1));
+		}
+		else if (strobeInterval < 0)
+		{
+			strobeInterval = abs(strobeInterval);
+			eFPS = (int)((curfps * strobeInterval) / (strobeInterval + 1));
+		}
+
 		switch( cl_showfps->integer )
 		{
 		case 3:
@@ -111,14 +123,21 @@ void SCR_DrawFPS( void )
 			break;
 		case 1:
 		default:
-			Q_snprintf( fpsstring, sizeof( fpsstring ), "%4i fps", curfps );
+			if (strobeInterval == 0)
+			{
+				Q_snprintf(fpsstring, sizeof(fpsstring), "%4i fps", curfps);
+			}
+			else
+			{
+				Q_snprintf(fpsstring, sizeof(fpsstring), "%4i FPS\n%3i eFPS", curfps, eFPS);
+			}
 		}
 
 		MakeRGBA( color, 255, 255, 255, 255 );
 	}
 
 	Con_DrawStringLen( fpsstring, &offset, NULL );
-	Con_DrawString( scr_width->integer - offset - 2, 4, fpsstring, color );
+	Con_DrawString( scr_width->integer - offset - 5, 4, fpsstring, color );
 }
 
 /*

--- a/engine/client/cl_scrn.c
+++ b/engine/client/cl_scrn.c
@@ -59,6 +59,8 @@ void SCR_DrawFPS( void )
 	double		newtime;
 	char		fpsstring[64];
 	int		offset;
+	int strobeInterval = r_strobe->integer; //cvar: r_strobe
+	int eFPS; //Effective FPS (strobing effect)
 
 	if( cls.state != ca_active ) return; 
 	if( !cl_showfps->integer || cl.background ) return;
@@ -101,8 +103,6 @@ void SCR_DrawFPS( void )
 		/*if( !avgrate ) avgrate = ( maxfps - minfps ) / 2.0f;
 		else */avgrate += ( calc - avgrate ) / host.framecount;
 
-		int strobeInterval = r_strobe->integer;
-		int eFPS; //Effective FPS (strobing effect)
 		if (strobeInterval > 0)
 		{
 			eFPS = (int)((curfps) / (strobeInterval + 1));

--- a/engine/client/console.c
+++ b/engine/client/console.c
@@ -1704,14 +1704,12 @@ void Con_DrawSolidConsole( float frac, qboolean fill )
 		con_rect.y = y - scr_width->value * 3 / 4;
 		con_rect.w = scr_width->value;
 		con_rect.h = scr_width->value * 3 / 4;
-
 		if( fill )
 		{
 			GL_SetRenderMode( kRenderNormal );
 			if( con_black->integer )
 			{
 				pglColor4ub( 0, 0, 0, 255 );
-				
 				R_DrawStretchPic( con_rect.x, con_rect.y, con_rect.w, con_rect.h, 0, 0, 1, 1, cls.fillImage );
 			}
 			else

--- a/engine/client/console.c
+++ b/engine/client/console.c
@@ -33,6 +33,8 @@ convar_t	*con_fontscale;
 convar_t	*con_fontnum;
 convar_t	*vgui_utf8;
 
+conrect_t	con_rect;
+
 static int g_codepage = 0;
 static qboolean g_utf8 = false;
 
@@ -1698,18 +1700,24 @@ void Con_DrawSolidConsole( float frac, qboolean fill )
 		y *= frac;
 	if( y >= 1 )
 	{
+		con_rect.x = 0;
+		con_rect.y = y - scr_width->value * 3 / 4;
+		con_rect.w = scr_width->value;
+		con_rect.h = scr_width->value * 3 / 4;
+
 		if( fill )
 		{
 			GL_SetRenderMode( kRenderNormal );
 			if( con_black->integer )
 			{
 				pglColor4ub( 0, 0, 0, 255 );
-				R_DrawStretchPic( 0, y - scr_width->value * 3 / 4, scr_width->value, scr_width->value * 3 / 4, 0, 0, 1, 1, cls.fillImage );
+				
+				R_DrawStretchPic( con_rect.x, con_rect.y, con_rect.w, con_rect.h, 0, 0, 1, 1, cls.fillImage );
 			}
 			else
 			{
 				pglColor4ub( 255, 255, 255, 255 );
-				R_DrawStretchPic( 0, y - scr_width->value * 3 / 4, scr_width->value, scr_width->value * 3 / 4, 0, 0, 1, 1, con.background );
+				R_DrawStretchPic( con_rect.x, con_rect.y, con_rect.w, con_rect.h, 0, 0, 1, 1, con.background );
 			}
 		}
 		else
@@ -1718,12 +1726,12 @@ void Con_DrawSolidConsole( float frac, qboolean fill )
 			if( con_black->value )
 			{
 				pglColor4ub( 0, 0, 0, 255 * con_alpha->value );
-				R_DrawStretchPic( 0, y - scr_width->value * 3 / 4, scr_width->value, scr_width->value * 3 / 4, 0, 0, 1, 1, cls.fillImage );
+				R_DrawStretchPic( con_rect.x, con_rect.y, con_rect.w, con_rect.h, 0, 0, 1, 1, cls.fillImage );
 			}
 			else
 			{
 				pglColor4ub( 255, 255, 255, 255 * con_alpha->value );
-				R_DrawStretchPic( 0, y - scr_width->value * 3 / 4, scr_width->value, scr_width->value * 3 / 4, 0, 0, 1, 1, con.background );
+				R_DrawStretchPic( con_rect.x, con_rect.y, con_rect.w, con_rect.h, 0, 0, 1, 1, con.background );
 			}
 		}
 		pglColor4ub( 255, 255, 255, 255 );

--- a/engine/client/gl_local.h
+++ b/engine/client/gl_local.h
@@ -363,6 +363,7 @@ qboolean R_InitRenderAPI( void );
 void R_SetupFrustum( void );
 void R_FindViewLeaf( void );
 void R_DrawFog( void );
+void R_Strobe( void );
 
 #define cmatrix3x4 vec4_t *const
 #define cmatrix4x4 vec4_t *const
@@ -699,6 +700,7 @@ extern convar_t	*r_lightmap;
 extern convar_t	*r_fastsky;
 extern convar_t	*r_vbo;
 extern convar_t	*r_bump;
+extern convar_t	*r_strobe;
 
 extern convar_t *mp_decals;
 
@@ -709,4 +711,4 @@ extern convar_t	*vid_texgamma;
 extern convar_t	*vid_mode;
 extern convar_t *vid_highdpi;
 
-#endif//GL_LOCAL_H
+#endif //GL_LOCAL_H

--- a/engine/client/vid_common.c
+++ b/engine/client/vid_common.c
@@ -78,6 +78,7 @@ convar_t	*r_lightmap;
 convar_t	*r_fastsky;
 convar_t	*r_vbo;
 convar_t 	*r_bump;
+convar_t	*r_strobe;
 convar_t	*mp_decals;
 
 convar_t	*vid_displayfrequency;
@@ -1007,6 +1008,18 @@ static void R_CheckVBO( void )
 
 /*
 ===============
+R_initStrobe
+
+register strobe cvar
+===============
+*/
+static inline void R_initStrobe( void )
+{
+	r_strobe = Cvar_Get("r_strobe", "0", CVAR_ARCHIVE, "black frame insertion interval");
+}
+
+/*
+===============
 R_Init
 ===============
 */
@@ -1047,6 +1060,7 @@ qboolean R_Init( void )
 	R_StudioInit();
 	R_ClearDecals();
 	R_ClearScene();
+	R_initStrobe();
 
 	// initialize screen
 	SCR_Init();

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -24,6 +24,8 @@ extern "C" {
 
 #include "backends.h"
 #include "defaults.h"
+//#include "wrect.h"
+
 //
 // check if selected backend not allowed
 //
@@ -1075,6 +1077,18 @@ void Con_ClearAutoComplete();
 //
 // console.c
 //
+
+//#define SolidConsoleX 0
+//#define SolidConsoleY (y - scr_width->value * 3 / 4)
+//#define SolidConsoleW (scr_width->value)
+//#define SolidConsoleH (scr_width->value * 3 / 4)
+//extern wrect_t con_rect; //Float - Int incompatibility
+typedef struct conrect_s
+{
+	float x, y, w, h;
+}conrect_t;
+extern conrect_t con_rect;
+
 void Con_Clear( void );
 
 extern const char *svc_strings[256];


### PR DESCRIPTION
Simple strobe support with black frame insertion (replacement) technique.

**Purpose**
Provides motion clarity by **eliminating motion blur** on high frequency monitors.

**How**
Replaces certain amount of consequent frames with black frames. This makes a scanning effect like CRT monitors.

**Usage**
Set **r_strobe** cvar to the black frame insertion interval (black frame count) you want (ideal values for 144hz monitors are probably **-2, -1 = 1, 2, 3**) . Frame display interval can be changed with gl_swapInterval cvar. Use cl_showfps 1 to see the actual / effective fps (displayed non-black frame count in 1 second).

Note that **V-Sync** must be **active** to enable this! (gl_swapInterval != 0)

- If r_strobe is positive, some rendered frames will be replaced with black frame
For example result of **r_strobe = 3** will be: _black-black-black-normal-black-black-black-normal-black-black-black-normal_

- If r_strobe is negative, the procedure will be the opposite.
For example result of **r_strobe = -4** will be: _normal-normal-normal-normal-black-normal-normal-normal-normal-black_

**Issues**
- Actual brightness gets reduced to **half** (and perceived brightness will be lowered but not as much as actual brightness) if _r_strobe_ is set to 1  more if >1 less if <-1. This can be corrected somehow by altering gamma and brightness I believe. Because this is just like pulse width modulation synchronized to v-sync frames. And there are several methods to overcome PWM brightness issue. Implementing adaptive version of this is on todo list.

- FPS will always be lowered. Actual or effective FPS (frames that are not black) gets reduced to **half**  if _r_strobe_ is set to 1 or -1 more if >1 less if <-1 .

- This will trigger epileptic attacks on epileptic patients.

- Even on 144hz monitors, flickering may happen.

- Perceived picture quality will be worse. Much worse on IPS, VA or slow TN panels.

- Frames that will be black are rendered for no rational reason. TODO: Consider vsync timings and do not render the supposed black frame at all.

- Ghosting effect may increase.

Web Demo: [https://www.testufo.com/blackframes#count=2&bonusufo=0&equalizer=1&background=000000](https://www.testufo.com/blackframes#count=2&bonusufo=0&equalizer=1&background=000000)

Not tested on Android yet!
