### PR TITLE
Fix crash bug when GL_EXT_compiled_vertex_array does not exist.

### DIFF
--- a/engine/platform/sdl/gl_sdl.c
+++ b/engine/platform/sdl/gl_sdl.c
@@ -56,6 +56,7 @@ static dllfunc_t opengl_110funcs[] =
 { "glDepthRange"         , (void **)&pglDepthRange },
 { "glFrontFace"          , (void **)&pglFrontFace },
 { "glDrawElements"       , (void **)&pglDrawElements },
+{ "glDrawArrays"         , (void **)&pglDrawArrays },
 { "glColorMask"          , (void **)&pglColorMask },
 { "glIndexPointer"       , (void **)&pglIndexPointer },
 { "glVertexPointer"      , (void **)&pglVertexPointer },
@@ -200,7 +201,6 @@ static dllfunc_t compiledvertexarrayfuncs[] =
 {
 { "glLockArraysEXT"   , (void **)&pglLockArraysEXT },
 { "glUnlockArraysEXT" , (void **)&pglUnlockArraysEXT },
-{ "glDrawArrays"      , (void **)&pglDrawArrays },
 { NULL, NULL }
 };
 


### PR DESCRIPTION
glDrawArrays() is a standard OpenGL 1.1 function, which does not belong to GL_EXT_compiled_vertex_array extension:
https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_compiled_vertex_array.txt

The crash happened on Intel HD Graphics 520 + Mac OS X 10.13.3, as pglDrawArrays is a NULL pointer if GL_EXT_compiled_vertex_array does not exist.