### PR TITLE
Added consistent debugging preprocessor define and fixed DEBUG_BREAK

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -161,10 +161,13 @@ else()
 	add_definitions(-DNO_LIBDL)
 endif()
 
+if( ${CMAKE_BUILD_TYPE} STREQUAL "Debug" )
+	add_definitions(-D_DEBUG)
+endif()
+
 if(XASH_RELEASE)
 	add_definitions(-DXASH_RELEASE)
 else()
-	add_definitions(-D_DEBUG)
 	execute_process(COMMAND "git" "rev-parse" "--short" "HEAD"
 		WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 		OUTPUT_VARIABLE SHORT_HASH

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -97,7 +97,7 @@ else()
 		add_definitions(-DUSE_SELECT)
 	endif()
 	add_definitions(-DCOLORIZE_CONSOLE)
-endif() 
+endif()
 
 if(LINUX)
 	add_definitions(-DGDB_BREAK)
@@ -164,6 +164,7 @@ endif()
 if(XASH_RELEASE)
 	add_definitions(-DXASH_RELEASE)
 else()
+	add_definitions(-D_DEBUG)
 	execute_process(COMMAND "git" "rev-parse" "--short" "HEAD"
 		WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 		OUTPUT_VARIABLE SHORT_HASH


### PR DESCRIPTION
For reference: https://github.com/FWGS/xash3d/issues/371

This pull request is in 2 parts:

1. Ensuring a consistent preprocessor `#define` is present to indicate debug compilation. I've modified the engine's `CMakeLists.txt` to add a `_DEBUG` flag if the build configuration is not release; I considered making it `XASH_DEBUG` in complement to `XASH_RELEASE`, but there were a handful of instances in the code where `_DEBUG` was already used a la MSVC, so I thought that would be more consistent.
2. Fixing `DEBUG_BREAK` not functioning on non-Windows platforms. There was no implementation at all for Mac, so I added that; the Linux implementation didn't work because it depended on a `GDB_BREAK` define, which I couldn't find anywhere else in the code or on the internet at large. I replaced the conditional with a check for Linux or variants of BSD.

Of course, all changes are up for discussion to determine what the best course of action is.