### PR TITLE
Fixed potential VBO index buffer overflow

### DIFF
--- a/engine/client/gl_rsurf.c
+++ b/engine/client/gl_rsurf.c
@@ -1979,7 +1979,7 @@ void R_GenerateVBO()
 				vbos.surfdata[i].startindex = vbo->array_len;
 				vbos.surfdata[i].texturenum = j;
 				vbo->array_len += surf->polys->numverts;
-				vbotex->len += surf->polys->numverts;
+				vbotex->len += 3 * (surf->polys->numverts - 2);	// 3 indices for n-2 vertices on each face - see R_AddSurfToVBO().
 				vbotex->vboarray = vbo;
 			}
 		}
@@ -2003,7 +2003,7 @@ void R_GenerateVBO()
 			vbotexture_t *vbotex = &vbos.textures[k * numtextures + j];
 
 			// preallocate index arrays
-			vbotex->indexarray = Mem_Alloc( vbos.mempool, sizeof( unsigned short ) * 6 *  vbotex->len );
+			vbotex->indexarray = Mem_Alloc( vbos.mempool, sizeof( unsigned short ) * vbotex->len );
 			vbotex->lightmaptexturenum = k;
 
 			if( maxindex < vbotex->len )
@@ -2035,7 +2035,7 @@ void R_GenerateVBO()
 
 					vbo = vbo->next;
 					vbotex = vbotex->next;
-					vbotex->indexarray = Mem_Alloc( vbos.mempool, sizeof( unsigned short ) * 6 *  vbotex->len );
+					vbotex->indexarray = Mem_Alloc( vbos.mempool, sizeof( unsigned short ) * vbotex->len );
 					vbotex->lightmaptexturenum = k;
 
 					// calculate limits for dlights
@@ -3309,9 +3309,13 @@ qboolean R_AddSurfToVBO( msurface_t *surf, qboolean buildlightmap )
 			// GL_TRIANGLE_FAN: 0 1 2 0 2 3 0 3 4 ...
 			for( index = indexbase + 2; index < indexbase + surf->polys->numverts; index++ )
 			{
-				vbotex->indexarray[vbotex->curindex++] = indexbase;
-				vbotex->indexarray[vbotex->curindex++] = index - 1;
-				vbotex->indexarray[vbotex->curindex++] = index;
+				// Make sure we don't overflow the index array.
+				if ( vbotex->curindex + 2 < vbotex->len )
+				{
+					vbotex->indexarray[vbotex->curindex++] = indexbase;
+					vbotex->indexarray[vbotex->curindex++] = index - 1;
+					vbotex->indexarray[vbotex->curindex++] = index;
+				}
 			}
 
 			// if surface has decals, add it to decal lightmapchain


### PR DESCRIPTION
https://github.com/FWGS/xash3d/issues/406

There were no checks on indices being written to in the VBO index buffer, and the size of the buffer was calculated somewhat arbitrarily. This caused overflow issues on my branch when I was attempting to load different BSP formats.

Index checks have been added, and the VBO index buffer size computation has been made accurate. In my fork I added a warning message if `vbotex->curindex` goes out of range, but because it can spam on every frame I thought it was best left out of the engine as a whole.