### PR TITLE
 Made linux' launch script work with spaces.

### DIFF
--- a/scripts/xash3d.sh
+++ b/scripts/xash3d.sh
@@ -29,10 +29,10 @@ fi
 UNAME=$(uname)
 if [ "$UNAME" = "Darwin" ]; then
 	# prepend our lib path to DYLD_LIBRARY_PATH
-	export DYLD_LIBRARY_PATH=${GAMEROOT}:$DYLD_LIBRARY_PATH
+	export DYLD_LIBRARY_PATH="${GAMEROOT}:$DYLD_LIBRARY_PATH"
 else
 	# prepend our lib path to LD_LIBRARY_PATH
-	export LD_LIBRARY_PATH=${GAMEROOT}:$LD_LIBRARY_PATH
+	export LD_LIBRARY_PATH="${GAMEROOT}:$LD_LIBRARY_PATH"
 fi
 
 # and launch the game


### PR DESCRIPTION
${GAMEROOT}:$LD_LIBRARY_PATH and ${GAMEROOT}:$DYLD_LIBRARY_PATH in the sh script were unquoted, meaning that if the path had spaces it would only output a newby-unfriendly error which
A) Could only be seen if the script was executed from a terminal (Not *in* a terminal from a file browser, as said terminal would show the error but close in a blink)
B) Wasn't easy to understand nor google-friendly