### PR TITLE
macOS : fix 64bit build

### DIFF
--- a/engine/common/system.c
+++ b/engine/common/system.c
@@ -141,7 +141,7 @@ qboolean Sys_DebuggerPresent( void )
 }
 
 #undef DEBUG_BREAK
-#ifdef __i386__
+#if defined(__i386__) || defined(__x86_64__)
 #define DEBUG_BREAK \
 	if( Sys_DebuggerPresent() ) \
 		asm volatile("int $3;")

--- a/engine/server/sv_game.c
+++ b/engine/server/sv_game.c
@@ -3058,7 +3058,7 @@ void SV_SetStringArrayMode( qboolean dynamic )
 }
 
 #ifdef XASH_64BIT
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__APPLE__)
 #define USE_MMAP
 #include <sys/mman.h>
 #endif


### PR DESCRIPTION
and probably fixes #452 
As munmap always fails and loops on my Mac, maybe it should be disabled.